### PR TITLE
Finalise v0.7.4

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Version 0.7.4
+=============
+* Support `collections.abc` for Python 3.8+
+
 Version 0.7.1
 =============
 * Minor bug with version variable

--- a/rhinoplasty/_version.py
+++ b/rhinoplasty/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.2alpha"
+__version__ = "0.7.4"


### PR DESCRIPTION
Version number was chosen to avoid conflict with forked releases.